### PR TITLE
Fix osx-arm64 builds (copied) and skip `include_directories` in `pybind_interface/basic` for MacOS ARM64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,21 +1,5 @@
 set -ex
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # MacOS specific commands, this only needs to happen for ARM64
-    # but it doesn't hurt to do it for all MacOS builds
-    OPENMP_INCLUDE_DIR=$(echo ${BUILD_PREFIX}/lib/clang/*/include)
-    OpenMP_omp_LIBRARY=$(echo ${BUILD_PREFIX}/lib/libomp.dylib)
-    {
-        echo "set(OpenMP_INCLUDE_DIR \"${OPENMP_INCLUDE_DIR}\")"
-        echo "set(OpenMP_omp_LIBRARY \"${OpenMP_omp_LIBRARY}\")"
-        echo "set(OpenMP_CXX_FLAGS \"-fopenmp=libomp\")"
-        echo "set(OpenMP_CXX_LIB_NAMES \"omp\")"
-        echo "include_directories(\${OpenMP_INCLUDE_DIR})"
-        cat CMakeLists.txt
-    } > tmp-CMakeLists.txt
-    mv tmp-CMakeLists.txt CMakeLists.txt
-fi
-
 # Copied from https://github.com/conda-forge/slycot-feedstock/pull/47
 # because $ file ~/micromamba/envs/test5/lib/python3.9/site-packages/qsimcirq/qsim_decide.cpython-39-darwin.so
 # qsim_decide.cpython-39-darwin.so: Mach-O 64-bit bundle x86_64

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,4 +16,20 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     mv tmp-CMakeLists.txt CMakeLists.txt
 fi
 
+# Copied from https://github.com/conda-forge/slycot-feedstock/pull/47
+# because $ file ~/micromamba/envs/test5/lib/python3.9/site-packages/qsimcirq/qsim_decide.cpython-39-darwin.so
+# qsim_decide.cpython-39-darwin.so: Mach-O 64-bit bundle x86_64
+# and: (trimmed error message)
+# ❯ python -c "import qsimcirq"
+# Traceback (most recent call last):
+# ImportError: dlopen(.../qsim_decide.cpython-312-darwin.so, 0x0002): 
+# tried: '.../qsim_decide.cpython-312-darwin.so' (mach-o file, but is an 
+# incompatible architecture (have 'x86_64', need 'arm64'))
+if [ "$target_platform" = "osx-arm64" ]; then
+    export CMAKE_OSX_ARCHITECTURES="arm64"
+    # workaround for https://github.com/scikit-build/scikit-build/issues/589
+    rm -rf $PREFIX/lib/libpython$PY_VER.dylib
+    ln -sf $PREFIX/lib/libc++.dylib $PREFIX/lib/libpython$PY_VER.dylib
+fi
+
 python -m pip install . -vvv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ source:
     - patches/0007-Always-skip-test_cirq_qsim_gpu_amplitudes-because-no.patch  # [cuda_compiler_version != "None"]
     - patches/0008-Add-support-for-additional-CMake-arguments.patch
     - patches/0009-Use-CMAKE_SYSTEM_NAME-and-CMAKE_SYSTEM_PROCESSOR-for.patch
+    - patches/0010-Do-not-set-includes-on-Apple-arm64-in-basis.patch
 
 build:
   skip: true  # [win]

--- a/recipe/patches/0010-Do-not-set-includes-on-Apple-arm64-in-basis.patch
+++ b/recipe/patches/0010-Do-not-set-includes-on-Apple-arm64-in-basis.patch
@@ -1,0 +1,25 @@
+From 8a4ebbacc2af5814813a8c4be896342aa0c0c446 Mon Sep 17 00:00:00 2001
+From: Bas Nijholt <bas@nijho.lt>
+Date: Sat, 9 Dec 2023 01:20:59 -0800
+Subject: [PATCH] Do not set includes on Apple arm64 in basis
+
+---
+ pybind_interface/basic/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pybind_interface/basic/CMakeLists.txt b/pybind_interface/basic/CMakeLists.txt
+index ab9cd94..2e7beba 100644
+--- a/pybind_interface/basic/CMakeLists.txt
++++ b/pybind_interface/basic/CMakeLists.txt
+@@ -8,7 +8,7 @@ else()
+ endif()
+ 
+ 
+-if(APPLE)
++if(APPLE AND NOT APPLE_ARM)
+     set(CMAKE_CXX_STANDARD 14)
+     include_directories("/usr/local/include" "/usr/local/opt/llvm/include")
+     link_directories("/usr/local/lib" "/usr/local/opt/llvm/lib")
+-- 
+2.43.0
+


### PR DESCRIPTION
Currently the arm64 build:

```bash
❯ python -c "import qsimcirq"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/basnijholt/micromamba/envs/test6/lib/python3.12/site-packages/qsimcirq/__init__.py", line 17, in <module>
    from qsimcirq import qsim_decide
ImportError: dlopen(/Users/basnijholt/micromamba/envs/test6/lib/python3.12/site-packages/qsimcirq/qsim_decide.cpython-312-darwin.so, 0x0002): tried: '/Users/basnijholt/micromamba/envs/test6/lib/python3.12/site-packages/qsimcirq/qsim_decide.cpython-312-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/basnijholt/micromamba/envs/test6/lib/python3.12/site-packages/qsimcirq/qsim_decide.cpython-312-darwin.so' (no such file), '/Users/basnijholt/micromamba/envs/test6/lib/python3.12/site-packages/qsimcirq/qsim_decide.cpython-312-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


The setting of CMAKE_OSX_ARCHITECTURES and workaround for https://github.com/scikit-build/scikit-build/issues/589 
 is copied from https://github.com/conda-forge/slycot-feedstock/pull/47